### PR TITLE
Added logic to optionally support Github 2FA auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,21 @@ SAML_ISSUER=issuer-string
 SAML_CALLBACK_URL=/auth/saml/callback
 ```
 
+#### App Configuration
+
+Configuration is setup in `config/default.json`, check it out to get running. Below are some of the more important configuration options.
+
+###### Github
+
+Github configuration consists of an `oranizations` object that controls which organizations you'll be managing, as well as how.
+
+```json
+"github": {
+    "organizations": [
+        {
+            "name": "MyOrganization",
+            "defaultRoles"
+        }
+    ]
+}
+```

--- a/config/default.json
+++ b/config/default.json
@@ -3,7 +3,8 @@
         "organizations": [
             {
                 "name": "GannettDigital",
-                "defaultRoles": []
+                "defaultRole": "member",
+                "enforce2FA": true
             }
         ]
     }

--- a/models/User.js
+++ b/models/User.js
@@ -53,6 +53,12 @@ User.add({
                 type: String,
                 label: 'GitHub username',
                 dependsOn: deps.github
+            },
+            safe: {
+                type: Boolean,
+                default: false,
+                label: 'Safe Account (Do not enforce 2FA)',
+                dependsOn: deps.github
             }
         },
     }

--- a/routes/index.js
+++ b/routes/index.js
@@ -46,5 +46,5 @@ exports = module.exports = function(app) {
     app.get('/leave/:org', middleware.requireUser, middleware.requireGithubAuthentication, routes.views.org.leave);
     app.get('/members/:org', middleware.requireAdminUser, routes.views.admin.members);
     app.get('/remove/:org/:ghUser', middleware.requireAdminUser, routes.views.admin.remove);
-	
+	app.post('/remove/bulk/:org/members', middleware.requireAdminUser, routes.views.admin.batchRemove);
 };

--- a/routes/views/admin/batchRemove.js
+++ b/routes/views/admin/batchRemove.js
@@ -1,0 +1,40 @@
+var keystone = require('keystone'),
+    github = require('../../../utils/github'),
+    async = require('async');
+
+exports = module.exports = function(req, res) {
+	
+	var view = new keystone.View(req, res);
+	var locals = res.locals;
+	
+	// locals.section is used to set the currently selected
+	// item in the header navigation.
+	locals.section = 'members/' + req.params.org;
+    locals.org = req.params.org;
+    
+    view.on('post', function(next) {
+        var count = 0;
+        async.each(req.body.members.split(','), function(member, done) {
+            github.removeUserFromOrganizationViaAdmin(member, req.params.org, function(err, data) {
+                if (err) {
+                    locals.error = err;
+                    return done(err);
+                }
+                count++;
+                return done();
+            });
+        }, function(err) {
+            locals.count = count;
+            if (err) {
+                req.flash('error', 'Error removing users.');
+            } else {
+                req.flash('success', count + ' member(s) removed from ' + req.params.org);
+            }
+            next();
+        });
+    });
+	
+	// Redirect the view
+	view.render('admin/batchRemove');
+	
+};

--- a/routes/views/admin/members.js
+++ b/routes/views/admin/members.js
@@ -2,6 +2,7 @@ var keystone = require('keystone'),
     Users = keystone.list('User'),
     github = require('../../../utils/github'),
     async = require('async'),
+    config = require('config'),
     _ = require('lodash');
 
 exports = module.exports = function(req, res) {
@@ -12,7 +13,9 @@ exports = module.exports = function(req, res) {
 	// locals.section is used to set the currently selected
 	// item in the header navigation.
 	locals.section = 'members/' + req.params.org;
-    locals.org = req.params.org;
+    locals.org = _(config.get('github.organizations')).filter(function(org) {
+        return org.name === req.params.org;
+    }).first();
     locals.members = [];
     
     view.on('init', function(next) {
@@ -41,10 +44,28 @@ exports = module.exports = function(req, res) {
                     locals.notInSystem = _.filter(members, function(member) {
                         return localGithubAccounts.indexOf(member) < 0;
                     });
-                    console.log(locals.notInSystem);
                     locals.members = data;
                     next();
                 });
+            },
+            function(next) {
+                if (locals.org.enforce2FA) {
+                    github.getOrganizationMembers(req.params.org, true, function(err, members2FADisabled) {
+                        if (err) {
+                            return next(err);
+                        };
+                        locals.members = _.forEach(locals.members, function(member) {
+                            member.has2FA = members2FADisabled.indexOf(member.services.github.username) < 0;
+                        });
+                        locals.membersWithout2FA = _.filter(locals.members, function(member) {
+                            return member.has2FA === false; 
+                        });
+                        console.log(locals.membersWithout2FA);
+                        next();
+                    })
+                } else {
+                    next();
+                }
             }
         ], function(err) {
             next();

--- a/routes/views/admin/members.js
+++ b/routes/views/admin/members.js
@@ -57,10 +57,12 @@ exports = module.exports = function(req, res) {
                         locals.members = _.forEach(locals.members, function(member) {
                             member.has2FA = members2FADisabled.indexOf(member.services.github.username) < 0;
                         });
-                        locals.membersWithout2FA = _.filter(locals.members, function(member) {
+                        locals.membersWithout2FA = _(locals.members).filter(function(member) {
                             return member.has2FA === false; 
-                        });
-                        console.log(locals.membersWithout2FA);
+                        }).reduce(function(memo, iter) {
+                            memo.push(iter.services.github.username);
+                            return memo;
+                        }, []);
                         next();
                     })
                 } else {

--- a/templates/views/admin/batchRemove.jade
+++ b/templates/views/admin/batchRemove.jade
@@ -1,0 +1,10 @@
+extends ../../layouts/default
+
+block content
+    .container
+        h1 Batch Remove
+        if error 
+            p Oops, looks like there was an error removing members from #{org}.
+            pre= error
+        else
+            p You have removed #{count} members(s) from #{org}.

--- a/templates/views/admin/members.jade
+++ b/templates/views/admin/members.jade
@@ -4,6 +4,10 @@ block content
     .container
         h1 Manage Organization Members
         h3 Members of #{org.name}
+        div.right
+            form(method='POST', action='/remove/bulk/#{org.name}/members')
+                input(type='hidden', name='members', value= membersWithout2FA.join(','))
+                input(type='submit', value='Remove #{membersWithout2FA.length} non-2FA Member(s)')
         table.table.table-striped
             thead
                 tr

--- a/templates/views/admin/members.jade
+++ b/templates/views/admin/members.jade
@@ -7,7 +7,7 @@ block content
             div.pull-right
                 form(method='POST', action='/remove/bulk/#{org.name}/members')
                     input(type='hidden', name='members', value= membersWithout2FA.join(','))
-                    input.btn.btn-primary(type='submit', value='Remove #{membersWithout2FA.length} non-2FA Member(s)')
+                    input.btn.btn-primary(type='submit', value='Remove #{membersWithout2FA.length} non-2FA member(s)')
         h3 Members of #{org.name}
         table.table.table-striped
             thead
@@ -17,6 +17,7 @@ block content
                     td Github Username
                     if org.enforce2FA
                         td 2FA
+                    td Safe
                     td Actions
             tbody
                 for member in members
@@ -26,10 +27,17 @@ block content
                         td= member.services.github.username
                         if org.enforce2FA
                             td
-                                if member.has2FA
+                                if member.has2FA && !member.services.github.safe
                                     span.glyphicon.glyphicon-ok
-                                else
+                                else if !member.services.github.safe
                                     span.glyphicon.glyphicon-ban-circle
+                                else if member.services.github.safe
+                                    span.glyphicon.glyphicon-minus
+                        td
+                            if member.services.github.safe
+                                span.glyphicon.glyphicon-ok
+                            else
+                                span.glyphicon.glyphicon-ban-circle
                         td
                             a(href='/remove/#{org.name}/#{member.services.github.username}') Remove
         h3 #{org.name} members not in Middleman (#{notInSystem.length})

--- a/templates/views/admin/members.jade
+++ b/templates/views/admin/members.jade
@@ -3,11 +3,12 @@ extends ../../layouts/default
 block content
     .container
         h1 Manage Organization Members
+        if org.enforce2FA && membersWithout2FA.length > 0
+            div.pull-right
+                form(method='POST', action='/remove/bulk/#{org.name}/members')
+                    input(type='hidden', name='members', value= membersWithout2FA.join(','))
+                    input.btn.btn-primary(type='submit', value='Remove #{membersWithout2FA.length} non-2FA Member(s)')
         h3 Members of #{org.name}
-        div.right
-            form(method='POST', action='/remove/bulk/#{org.name}/members')
-                input(type='hidden', name='members', value= membersWithout2FA.join(','))
-                input(type='submit', value='Remove #{membersWithout2FA.length} non-2FA Member(s)')
         table.table.table-striped
             thead
                 tr

--- a/templates/views/admin/members.jade
+++ b/templates/views/admin/members.jade
@@ -3,13 +3,15 @@ extends ../../layouts/default
 block content
     .container
         h1 Manage Organization Members
-        h3 Members in #{org} with matching account
+        h3 Members of #{org.name}
         table.table.table-striped
             thead
                 tr
                     td Name
                     td Email
                     td Github Username
+                    if org.enforce2FA
+                        td 2FA
                     td Actions
             tbody
                 for member in members
@@ -17,9 +19,15 @@ block content
                         td #{member.name.first} #{member.name.last}
                         td= member.email
                         td= member.services.github.username
+                        if org.enforce2FA
+                            td
+                                if member.has2FA
+                                    span.glyphicon.glyphicon-ok
+                                else
+                                    span.glyphicon.glyphicon-ban-circle
                         td
-                            a(href='/remove/#{org}/#{member.services.github.username}') Remove
-        h3 Members without matching account (#{notInSystem.length})
+                            a(href='/remove/#{org.name}/#{member.services.github.username}') Remove
+        h3 #{org.name} members not in Middleman (#{notInSystem.length})
         table.table.table-striped
             thead
                 tr
@@ -30,4 +38,4 @@ block content
                     tr
                         td= member
                         td
-                            a(href='/remove/#{org}/#{member}') Remove
+                            a(href='/remove/#{org.name}/#{member}') Remove

--- a/utils/github.js
+++ b/utils/github.js
@@ -91,14 +91,19 @@ function _recursePagination(client, data, members, cb) {
     };
 }
 
-exports.getOrganizationMembers = function(org, cb) {
+exports.getOrganizationMembers = function(org, twofactor, cb) {
+    if (_.isFunction(twofactor)) {
+        cb = twofactor;
+        twofactor = false;
+    };
     github.authenticate({
         type: 'oauth',
         token: process.env.GITHUB_ADMIN_TOKEN
     });
     github.orgs.getMembers({
         org: org,
-        per_page: 100
+        per_page: 100,
+        filter: twofactor ? '2fa_disabled' : 'all'
     }, function(err, data) {
         _recursePagination(github, data, data, function(err, members) {
             var reduced = _.reduce(members, function(memo, iter) {


### PR DESCRIPTION
If `enforce2FA` is enabled in the configuration for your organization you'll now see columns displaying the status. You'll also get a button to bulk remove any users w/o 2FA enabled, and are not marked as safe/service level accounts.

Closes #2.
